### PR TITLE
Fix Bug: unexpected end of config JSON #39

### DIFF
--- a/src/commands/config/org/set.ts
+++ b/src/commands/config/org/set.ts
@@ -58,7 +58,7 @@ export default class Set extends Command<SetOrgJson> {
     this.userConfig.organization.current = response.organization;
     // Make sure we clear the current project when we switch orgs
     this.userConfig.project.current = undefined;
-    this.userConfig.save();
+    await this.userConfig.save();
 
     return {success: true, message: 'Set current organization.'};
   }

--- a/src/commands/config/project/set.ts
+++ b/src/commands/config/project/set.ts
@@ -59,7 +59,7 @@ export default class Set extends Command<SetProjectJson> {
     ]);
 
     this.userConfig.project.current = response.project;
-    this.userConfig.save();
+    await this.userConfig.save();
 
     return {success: true, message: 'Set current project'};
   }


### PR DESCRIPTION
<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
<!-- A brief, mostly non technical summary of what this change does -->

The await keyword was missed when calling the save config methods, as a result a timing issue could occur in the login sequence where the config project set command is run whilst the previous command is still saving the config file, hence it reads an empty file resulting in the error.
Closes #39 

### Type

- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change

# Self Review

- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
