### PR TITLE
Added missing --multi for oclif readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "prepack": "npm run build && oclif manifest && oclif readme --multi",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "coverage": "nyc npm run test",
-    "version": "oclif readme && git add README.md"
+    "version": "oclif readme --multi && git add README.md docs/*"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION


<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
<!-- A brief, mostly non technical summary of what this change does -->
When --multi was added to the prepack script, it was not added to the version script, probably causing the issues seen in #40 and #42.


### Type

- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change
