### PR TITLE
Added release workflows

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,20 @@
+name: Publist NPM
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test
+
+  create-release:
+   needs: test
+   runs-on: ubuntu-latest
+   steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        registry-url: https://registry.npmjs.org/
+    - name: Install dependancies
+      run: npm ci
+    - name: Pack tarballs
+      run: npm run tarballs
+    - name: Create release
+      uses: softprops/action-gh-release@v1
+      with:
+        # Releases should be manually validated before being published
+        draft: true
+        files: dist/*.tar.*
+        generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "npm run lint",
     "prepack": "npm run build && oclif manifest && oclif readme --multi",
+    "tarballs": "oclif pack tarballs",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "coverage": "nyc npm run test",
     "version": "oclif readme --multi && git add README.md docs/*"


### PR DESCRIPTION
<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

2 new workflows, 1 to create a release and 1 to publish the package to NPM. The release workflow tests and builds the tarballs before creating a draft release when a new tag matching the pattern `v*.*.*` is created. This draft release can then be manually checked before being published. The npm workflow then, when a release is published, builds the NPM package from the release to NPM.

### Type

- [ ] Feature
- [ ] Bug Fix
- [ ] Breaking Change
- [x] Workflow

