### PR TITLE
Switched endpoint for remove roles validation

### DIFF
--- a/src/commands/org/accounts/edit.ts
+++ b/src/commands/org/accounts/edit.ts
@@ -42,6 +42,38 @@ export default class Edit extends Command<{success: boolean}> {
       roles.push(role.id);
     }
 
+    // Have to use roles currently attached to account. See #80
+    const accountRoles: string[] = [];
+    // Only need to call API if the user tries to remove any roles
+    if (flags['remove-role'] && flags['remove-role'].length > 0) {
+      const rawAccountRoles = await this.api.get<T.OrgAccount>(
+        `organizations/${orgId}/accounts/${flags['user-id']}`
+      );
+
+      // The location of permissions is not consistent, hence we need
+      // to check a couple of different places
+      if (rawAccountRoles.app_metadata) {
+        if (
+          rawAccountRoles.app_metadata.org_roles &&
+          (rawAccountRoles.app_metadata.org_roles as Record<string, string[]>)[orgId]
+        ) {
+          for (const role of (rawAccountRoles.app_metadata.org_roles as Record<string, string[]>)[
+            orgId
+          ]) {
+            accountRoles.push(role);
+          }
+        } else if (rawAccountRoles.app_metadata[orgId]) {
+          for (const role of rawAccountRoles.app_metadata[orgId] as string[]) {
+            accountRoles.push(role);
+          }
+        }
+      } else if (rawAccountRoles.permissions) {
+        for (const role of rawAccountRoles.permissions) {
+          accountRoles.push(role);
+        }
+      }
+    }
+
     // We have to check these and then run additions separately to avoid
     // partial updates
     if (flags['add-role'] && flags['add-role'].length > 0) {
@@ -54,8 +86,8 @@ export default class Edit extends Command<{success: boolean}> {
 
     if (flags['remove-role'] && flags['remove-role'].length > 0) {
       for (const role of flags['remove-role']) {
-        if (!roles.includes(role)) {
-          throw new Error(`Unrecognized role ${role}`);
+        if (!accountRoles.includes(role)) {
+          throw new Error(`${role} not found on user ${flags['user-id']}.`);
         }
       }
     }


### PR DESCRIPTION


<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

Fix Remove role from user when role has already been deleted from organisation #80

Now in order to validate roles to remove from a given account, we fetch the list of roles active on that account and use that to validate the roles instead of using the organisations roles.

Closes #80 

### Type

- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change

## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/9f40b06c-f85c-460b-bd54-5d7395472110)


# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artefacts left over from development
- [x] I have tested my code to ensure it functions as intended
