### PR TITLE
Added whoami command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ USAGE
 | `APIMETRICS_TOKEN_URL`      | :x:      | URL to use when requesting an access token for OAuth based login. Defaults to `https://auth.apimetrics.io/oauth/token`.                                         |
 | `APIMETRICS_CODE_URL`       | :x:      | URL to use when requesting an authorization code for OAuth based login. Defaults to `https://auth.apimetrics.io/oauth/device/code`.                             |
 | `APIMETRICS_REVOKE_URL`     | :x:      | URL to use when revoking refresh tokens. Defaults to `https://auth.apimetrics.io/oauth/revoke`.                                                                 |
+| `APIMETRICS_USERINFO_URL`   | :x:      | URL to use when fetching user info. Defaults to `https://auth.apimetrics.io/userinfo`.                                                                          |
 | `APIMETRICS_CLIENT_ID`      | :x:      | Client ID to use for OAuth based login.                                                                                                                         |
 | `APIMETRICS_CONFIG_DIR`     | :x:      | Directory to store configuration for the CLI. Defaults to `~/.config/apimetrics` on UNIX and `%LOCALAPPDATA%\apimetrics` on Windows.                            |
 | ~~`XDG_CONFIG_HOME`~~       | :x:      | Directory to store configuration for the CLI. Not recommended for use. Use `APIMETRICS_CONFIG_DIR` instead. `APIMETRICS_CONFIG_DIR` takes priority if also set. |

--- a/docs/info.md
+++ b/docs/info.md
@@ -5,6 +5,7 @@ Information about APImetrics monitoring infrastructure.
 
 * [`apimetrics info locations`](#apimetrics-info-locations)
 * [`apimetrics info regions`](#apimetrics-info-regions)
+* [`apimetrics info whoami`](#apimetrics-info-whoami)
 
 ## `apimetrics info locations`
 
@@ -80,3 +81,29 @@ EXAMPLES
 ```
 
 _See code: [src/commands/info/regions.ts](https://github.com/APImetrics/APIm-CLI/blob/v0.1.1/src/commands/info/regions.ts)_
+
+## `apimetrics info whoami`
+
+Show details about the currently logged in user.
+
+```
+USAGE
+  $ apimetrics info whoami [--json]
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Show details about the currently logged in user.
+
+EXAMPLES
+  $ apimetrics info whoami
+  ID:                   auth0|109e70845ef23eb4099c209p
+  Name:                 Bob
+  Email:                bob@example.com
+  MFA enabled:          false
+  Current Organization: companya
+  Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM
+```
+
+_See code: [src/commands/info/whoami.ts](https://github.com/APImetrics/APIm-CLI/blob/v0.1.1/src/commands/info/whoami.ts)_

--- a/src/base-command/api.ts
+++ b/src/base-command/api.ts
@@ -3,7 +3,7 @@ import {Auth} from './auth';
 import fetch, {RequestInit} from 'node-fetch';
 import {Config} from './config';
 import {debug} from 'debug';
-import {ApiError as TApiError, ListResponse} from './types';
+import {ApiError as TApiError, ListResponse, UserInfo} from './types';
 import {ApiError} from './errors';
 
 type RequestOptions = {
@@ -155,6 +155,14 @@ export class Api {
    */
   public async logout(): Promise<void> {
     return this.auth.logout();
+  }
+
+  /**
+   * Make call to OIDC userinfo endpoint
+   * @returns User information
+   */
+  public async userinfo(): Promise<UserInfo> {
+    return this.auth.userinfo();
   }
 
   /**

--- a/src/base-command/types/index.ts
+++ b/src/base-command/types/index.ts
@@ -8,6 +8,7 @@ import {OrgAccount} from './orgaccount';
 import {Project} from './project';
 import {Role} from './role';
 import {Schedule} from './schedule';
+import {UserInfo} from './userinfo';
 import {UserProjects} from './userprojects';
 import {Webhook} from './webhook';
 import {Workflow} from './workflow';
@@ -23,6 +24,7 @@ export {
   Project,
   Role,
   Schedule,
+  UserInfo,
   UserProjects,
   Webhook,
   Workflow,

--- a/src/base-command/types/userinfo.ts
+++ b/src/base-command/types/userinfo.ts
@@ -1,0 +1,16 @@
+/* eslint-disable camelcase */
+export type UserInfo = {
+  sub: string;
+  nickname: string;
+  name: string;
+  picture: string;
+  updated_at: string;
+  email: string;
+  email_verified: string;
+  'https://client.apimetrics.io/org_ids': string[];
+  'https://client.apimetrics.io/roles': Record<string, string[]>;
+  'https://client.apimetrics.io/permissions': string[];
+  'https://client.apimetrics.io/use_mfa': boolean;
+  'https://client.apimetrics.io/fav_orgs': string[];
+  'https://client.apimetrics.io/fav_projects': string[];
+};

--- a/src/commands/info/whoami.ts
+++ b/src/commands/info/whoami.ts
@@ -1,0 +1,80 @@
+import {Command} from '../../base-command';
+
+export type WhoamiResponse = {
+  success: boolean;
+  whoami: {
+    id: string;
+    name: string;
+    email: string;
+    mfa: boolean;
+    // eslint-disable-next-line camelcase
+    current_org: string;
+    // eslint-disable-next-line camelcase
+    current_project: string;
+  };
+};
+
+export default class Whoami extends Command<WhoamiResponse> {
+  static description = 'Show details about the currently logged in user.';
+
+  static examples = [
+    `<%= config.bin %> <%= command.id %>
+ID:                   auth0|109e70845ef23eb4099c209p
+Name:                 Bob
+Email:                bob@example.com
+MFA enabled:          false
+Current Organization: companya
+Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
+  ];
+
+  public async run(): Promise<WhoamiResponse> {
+    const userinfo = await this.api.userinfo();
+    const data: Record<string, {title: string; value: any}> = {
+      id: {
+        title: 'ID',
+        value: userinfo.sub,
+      },
+      name: {
+        title: 'Name',
+        value: userinfo.nickname,
+      },
+      email: {
+        title: 'Email',
+        value: userinfo.email,
+      },
+      mfa: {
+        title: 'MFA enabled',
+        value: userinfo['https://client.apimetrics.io/use_mfa'],
+      },
+      currentOrg: {
+        title: 'Current Organization',
+        value: this.userConfig.organization.current || '',
+      },
+      currentProject: {
+        title: 'Current Project',
+        value: this.userConfig.project.current || '',
+      },
+    };
+
+    // +2 for colon + space between longest title and value
+    const padding = Math.max(...Object.values(data).map((entry) => entry.title.length)) + 2;
+
+    for (const entry of Object.values(data)) {
+      this.log((entry.title + ': ').padEnd(padding) + entry.value);
+    }
+
+    return {
+      success: true,
+      whoami: {
+        id: data.id.value,
+        name: data.name.value,
+        email: data.email.value,
+        mfa: data.mfa.value,
+        // eslint-disable-next-line camelcase
+        current_org: data.currentOrg.value,
+        // eslint-disable-next-line camelcase
+        current_project: data.currentProject.value,
+      },
+    };
+  }
+}

--- a/test/commands/info/whoami.test.ts
+++ b/test/commands/info/whoami.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable camelcase */
+import {expect, test} from '@oclif/test';
+import * as fs from 'fs-extra';
+
+const userinfo = {
+  sub: 'auth0|109e70845ef23eb4099c209p',
+  nickname: 'Bob',
+  name: 'bob@example.com',
+  picture: 'https://s.gravatar.com/avatar/abc123',
+  updated_at: '2023-10-12T19:00:00.589Z',
+  email: 'bob@example.com',
+  email_verified: false,
+  'https://client.apimetrics.io/org_ids': ['companya'],
+  'https://client.apimetrics.io/roles': {
+    companya: ['DEFAULT'],
+  },
+  'https://client.apimetrics.io/permissions': [],
+  'https://client.apimetrics.io/use_mfa': false,
+  'https://client.apimetrics.io/fav_orgs': [],
+  'https://client.apimetrics.io/fav_projects': [],
+};
+
+describe('info whoami', () => {
+  const bearerAuth = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'companya'},
+        project: {current: 'ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'bearer',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_USERINFO_URL: 'https://auth.apimetrics.io/userinfo'});
+
+  bearerAuth
+    .nock('https://auth.apimetrics.io', (api) => api.get('/userinfo').reply(200, userinfo))
+    .stdout()
+    .command(['info:whoami'])
+    .it('Show current user information', (ctx) => {
+      expect(ctx.stdout).to.equal(`ID:                   auth0|109e70845ef23eb4099c209p
+Name:                 Bob
+Email:                bob@example.com
+MFA enabled:          false
+Current Organization: companya
+Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`);
+    });
+});

--- a/test/commands/info/whoami.test.ts
+++ b/test/commands/info/whoami.test.ts
@@ -45,6 +45,7 @@ Name:                 Bob
 Email:                bob@example.com
 MFA enabled:          false
 Current Organization: companya
-Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`);
+Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM
+`);
     });
 });


### PR DESCRIPTION
<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
<!-- A brief, mostly non technical summary of what this change does -->
Add a command to display information about the current logged in user and current working project and organisation.

Closes #68 

### Type

- [x] Feature
- [ ] Bug Fix
- [ ] Breaking Change

# Technical Description
<!-- 
How does this change work? Why was this approach chosen? Were any 
alternative approaches considered?
-->

The project and organisation settings are pulled from the `config.json` file whilst the user information is pulled from the `/userinfo` endpoint of the OIDC provider.

## Usage
```
Show details about the currently logged in user.

USAGE
  $ apimetrics info whoami [--json]

GLOBAL FLAGS
  --json  Format output as json.

DESCRIPTION
  Show details about the currently logged in user.

EXAMPLES
  $ apimetrics info whoami
  ID:                   auth0|109e70845ef23eb4099c209p
  Name:                 Bob
  Email:                bob@example.com
  MFA enabled:          false
  Current Organization: companya
  Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM

```

## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/8b4060c2-79e9-4e14-8313-e71556b3aca9)

# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
