### PR TITLE
Added list orgs commands.

### DIFF
--- a/docs/info.md
+++ b/docs/info.md
@@ -4,6 +4,7 @@
 Information about APImetrics monitoring infrastructure.
 
 * [`apimetrics info locations`](#apimetrics-info-locations)
+* [`apimetrics info orgs`](#apimetrics-info-orgs)
 * [`apimetrics info regions`](#apimetrics-info-regions)
 * [`apimetrics info whoami`](#apimetrics-info-whoami)
 
@@ -43,6 +44,42 @@ EXAMPLES
 ```
 
 _See code: [src/commands/info/locations.ts](https://github.com/APImetrics/APIm-CLI/blob/v0.1.1/src/commands/info/locations.ts)_
+
+## `apimetrics info orgs`
+
+List organizations the current user is a member of.
+
+```
+USAGE
+  $ apimetrics info orgs [--json] [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output
+    csv|json|yaml |  | [--csv | --no-truncate]] [--no-header | ]
+
+FLAGS
+  -x, --extended     show extra columns
+  --columns=<value>  only show provided columns (comma-separated)
+  --csv              output is csv format [alias: --output=csv]
+  --filter=<value>   filter property by partial string matching, ex: name=foo
+  --no-header        hide table header from output
+  --no-truncate      do not truncate output to fit screen
+  --output=<option>  output in a more machine friendly format
+                     <options: csv|json|yaml>
+  --sort=<value>     property to sort by (prepend '-' for descending)
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  List organizations the current user is a member of.
+
+EXAMPLES
+  $ apimetrics info orgs
+  Name                         ID        Subscription Level
+  ──────────────────────────── ──────── ──────────────────
+  Org with Enterprise contract companya CONTRACT
+  An Org                       companyb PLAN
+```
+
+_See code: [src/commands/info/orgs.ts](https://github.com/APImetrics/APIm-CLI/blob/v0.1.1/src/commands/info/orgs.ts)_
 
 ## `apimetrics info regions`
 

--- a/src/commands/info/orgs.ts
+++ b/src/commands/info/orgs.ts
@@ -1,0 +1,92 @@
+import {ux} from '@oclif/core';
+import {Command, T} from '../../base-command';
+
+export type OrgList = {
+  success: boolean;
+  organizations: T.UserProjects['organizations'];
+  roles: T.UserProjects['meta']['roles'];
+};
+
+export default class Orgs extends Command<OrgList> {
+  static description = 'List organizations the current user is a member of.';
+
+  static examples = [
+    `<%= config.bin %> <%= command.id %>
+Name                         ID        Subscription Level
+──────────────────────────── ──────── ──────────────────
+Org with Enterprise contract companya CONTRACT
+An Org                       companyb PLAN
+`,
+  ];
+
+  static flags = {
+    ...ux.table.flags(),
+  };
+
+  public async run(): Promise<OrgList> {
+    const {flags} = await this.parse(Orgs);
+
+    const {
+      organizations,
+      meta: {roles},
+    } = await this.api.get<T.UserProjects>('account/projects');
+
+    ux.table(
+      Object.values(organizations),
+      {
+        name: {
+          get: (row) => row.name,
+        },
+        id: {
+          header: 'ID',
+          get: (row) => row.id,
+        },
+        roles: {
+          get: (row) => roles[row.id]?.join(', ') || '',
+        },
+        subscriptionLevel: {
+          header: 'Subscription Level',
+          get: (row) => row.subscription_level,
+        },
+        billingAdminID: {
+          header: 'Billing Admin ID',
+          get: (row) => row.billing_admin_id,
+          extended: true,
+        },
+        enforce2fa: {
+          header: 'Enforce 2FA',
+          get: (row) => row.enforce_2fa,
+          extended: true,
+        },
+        passwordExpiryDays: {
+          header: 'Password Expiry Days',
+          get: (row) => row.password_expiry_days,
+          extended: true,
+        },
+        kmsEnabled: {
+          header: 'KMS Enabled',
+          get: (row) => row.kms_enabled,
+          extended: true,
+        },
+        tags: {
+          get: (row) => row.tags.join(', '),
+          extended: true,
+        },
+        systemTags: {
+          header: 'System Tags',
+          get: (row) => row.system_tags.join(', '),
+          extended: true,
+        },
+        created: {
+          get: (row) => row.created,
+          extended: true,
+        },
+      },
+      {
+        printLine: this.log.bind(this),
+        ...flags,
+      }
+    );
+    return {success: true, organizations: organizations, roles: roles};
+  }
+}

--- a/test/commands/info/orgs.test.ts
+++ b/test/commands/info/orgs.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable camelcase */
+import {expect, test} from '@oclif/test';
+import * as fs from 'fs-extra';
+
+const orgs = {
+  meta: {
+    roles: {
+      companya: ['DEFAULT'],
+      companyb: ['DEFAULT', 'ADMIN'],
+    },
+  },
+  organizations: {
+    companya: {
+      enforce_2fa: false,
+      tags: [],
+      password_expiry_days: 0,
+      system_tags: ['subscription_level:CONTRACT', 'active'],
+      billing_admin_id: null,
+      kms_enabled: false,
+      created: '2020-02-14T22:11:51.529661Z',
+      subscription_level: 'CONTRACT',
+      last_update: '2023-02-09T23:14:01.615261Z',
+      id: 'companya',
+      name: 'Org with Enterprise contract',
+    },
+    companyb: {
+      enforce_2fa: false,
+      tags: [],
+      password_expiry_days: 0,
+      system_tags: ['active', 'subscription_level:PLAN'],
+      billing_admin_id: 'abc123',
+      kms_enabled: false,
+      created: '2016-05-10T23:04:23.798000Z',
+      subscription_level: 'PLAN',
+      last_update: '2023-10-02T21:31:34.277156Z',
+      id: 'companyb',
+      name: 'An Org',
+    },
+    companyc: {
+      enforce_2fa: false,
+      tags: [],
+      password_expiry_days: 0,
+      system_tags: ['active', 'subscription_level:PLAN'],
+      billing_admin_id: 'abc123',
+      kms_enabled: false,
+      created: '2016-05-10T23:04:23.798000Z',
+      subscription_level: 'PLAN',
+      last_update: '2023-10-02T21:31:34.277156Z',
+      id: 'companyc',
+      name: 'Another Org',
+    },
+  },
+};
+
+describe('info orgs', () => {
+  const bearerAuth = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'abc123'},
+        project: {current: 'abc123'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'bearer',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'});
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) =>
+      api.get('/api/2/account/projects').reply(200, orgs)
+    )
+    .stdout()
+    .command(['info:orgs', '--output=json'])
+    .it('List all orgs with --output=json argument', (ctx) => {
+      const output = JSON.parse(ctx.stdout);
+      expect(output).to.deep.equal([
+        {
+          name: 'Org with Enterprise contract',
+          id: 'companya',
+          roles: 'DEFAULT',
+          subscriptionLevel: 'CONTRACT',
+        },
+        {
+          name: 'An Org',
+          id: 'companyb',
+          roles: 'DEFAULT, ADMIN',
+          subscriptionLevel: 'PLAN',
+        },
+        {
+          name: 'Another Org',
+          id: 'companyc',
+          roles: '',
+          subscriptionLevel: 'PLAN',
+        },
+      ]);
+    });
+});


### PR DESCRIPTION
Fix List users organisations #83

<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
List the organisations a user is a member of and their roles within that org.

Closes #83 

### Type

- [x] Feature
- [ ] Bug Fix
- [ ] Breaking Change

# Technical Description
<!-- 
How does this change work? Why was this approach chosen? Were any 
alternative approaches considered?
-->

## Usage
```
List organizations the current user is a member of.

USAGE
  $ apimetrics info orgs [--json] [--columns <value> | -x] [--sort <value>] [--filter <value>] [--output csv|json|yaml |  |
    [--csv | --no-truncate]] [--no-header | ]

FLAGS
  -x, --extended     show extra columns
  --columns=<value>  only show provided columns (comma-separated)
  --csv              output is csv format [alias: --output=csv]
  --filter=<value>   filter property by partial string matching, ex: name=foo
  --no-header        hide table header from output
  --no-truncate      do not truncate output to fit screen
  --output=<option>  output in a more machine friendly format
                     <options: csv|json|yaml>
  --sort=<value>     property to sort by (prepend '-' for descending)

GLOBAL FLAGS
  --json  Format output as json.

DESCRIPTION
  List organizations the current user is a member of.

EXAMPLES
  $ apimetrics info orgs
  Name                         ID        Subscription Level
  ──────────────────────────── ──────── ──────────────────
  Org with Enterprise contract companya CONTRACT
  An Org                       companyb PLAN

```

## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/282656a5-cb0d-4ea6-9d28-d43dc5ba1b36)

# Self Review

- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
