### PR TITLE
Default content type for call body

### DIFF
--- a/src/commands/calls/create.ts
+++ b/src/commands/calls/create.ts
@@ -59,6 +59,12 @@ ag9zfmFwaW1ldHJpY3MtcWNyFwsSClRlc3RTZXRjklafJhslw62dahoM`,
       }
     }
 
+    // #105 If we don't pass a content type we default to
+    // application/json. Prevents issues with web UI displaying body
+    if (flags.body && !headers.some((val) => val.key.toLowerCase() === 'content-type')) {
+      headers.push({key: 'Content-Type', value: 'application/json'});
+    }
+
     if (flags.accept) {
       headers = util.replaceHeader(headers, 'Accept', flags.accept);
     }

--- a/src/commands/calls/edit.ts
+++ b/src/commands/calls/edit.ts
@@ -99,6 +99,15 @@ export default class Edit extends Command<UpdatedCall> {
       }
     }
 
+    // #105 If we don't pass a content type we default to
+    // application/json. Prevents issues with web UI displaying body
+    if (
+      flags.body &&
+      !call.request.headers.some((val) => val.key.toLowerCase() === 'content-type')
+    ) {
+      call.request.headers.push({key: 'Content-Type', value: 'application/json'});
+    }
+
     if (flags.accept) {
       call.request.headers = util.replaceHeader(call.request.headers, 'Accept', flags.accept);
     }

--- a/test/commands/calls/create.test.ts
+++ b/test/commands/calls/create.test.ts
@@ -109,6 +109,77 @@ describe('calls create', () => {
       'Content-type: application/json',
     ])
     .it('Create call with headers and tags');
+
+  auth
+    .stdout()
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .post('/api/2/calls/', {
+          meta: {name: 'call', tags: []},
+          request: {
+            method: 'POST',
+            url: 'http://google.apimetrics.xyz/get',
+            headers: [
+              {key: 'Content-Type', value: 'text/plain'},
+              {key: 'Accept', value: 'application/json'},
+            ],
+            body: 'abc123456',
+          },
+        })
+        .reply(200, {id: '1234'})
+    )
+    .command([
+      'calls:create',
+      '--json',
+      '-n',
+      'call',
+      '--method',
+      'POST',
+      '-u',
+      'http://google.apimetrics.xyz/get',
+      '--accept',
+      'application/json',
+      '--header',
+      'Content-Type:text/plain',
+      '--body',
+      'abc123456',
+    ])
+    .it('Send body setting content type');
+
+  auth
+    .stdout()
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .post('/api/2/calls/', {
+          meta: {name: 'call', tags: []},
+          request: {
+            method: 'POST',
+            url: 'http://google.apimetrics.xyz/get',
+            headers: [
+              {key: 'Content-Type', value: 'application/json'},
+              {key: 'Accept', value: 'application/json'},
+            ],
+            body: 'abc123456',
+          },
+        })
+        .reply(200, {id: '1234'})
+    )
+    .command([
+      'calls:create',
+      '--json',
+      '-n',
+      'call',
+      '--method',
+      'POST',
+      '-u',
+      'http://google.apimetrics.xyz/get',
+      '--accept',
+      'application/json',
+      '--body',
+      'abc123456',
+    ])
+    .it('Send body default content type');
+
   auth
     .stderr()
     .command([

--- a/test/commands/calls/edit.test.ts
+++ b/test/commands/calls/edit.test.ts
@@ -120,6 +120,129 @@ describe('calls edit', () => {
     ])
     .it('Add and remove tags and headers');
 
+  auth
+    .stdout()
+    .nock('https://client.apimetrics.io', (api) => {
+      api.get('/api/2/calls/1234/').reply(200, {
+        meta: {
+          domain: 'google.apimetrics.xyz',
+          description: null,
+          tags: [
+            'apimetrics:meta:domain:google.apimetrics.xyz',
+            'apimetrics:meta:http:google_lb',
+            'apimetrics:meta:ns_host:Google+LLC',
+            'apimetrics:meta:server:gunicorn',
+            'apimetrics:meta:host:Google+LLC',
+          ],
+          accept: null,
+          content_type: null,
+          owner: 'ag9zfmFwaW1ldHJpY3MtcWNyEQsSBFVzZXIYgIDA1PLekQoM',
+          name: '=1+1',
+          created: '2021-01-28T01:19:19.594763Z',
+          last_update: '2022-07-19T22:38:53.838839Z',
+          workspace: 'global',
+          project_id: 'ag9zfmFwaW1ldHJpY3MtcWNyEQsSBFVzZXIYgIDA1PLekQoM',
+        },
+        request: {
+          body: null,
+          parameters: [],
+          url: 'http://google.apimetrics.xyz/get',
+          auth_id: null,
+          headers: [
+            {
+              key: 'Content-type',
+              value: 'text/plain',
+            },
+          ],
+          token_id: null,
+          method: 'GET',
+        },
+        id: 'ag9zfmFwaW1ldHJpY3MtcWNyFwsSClRlc3RTZXR1cDIYgIDA05v5mwoM',
+      });
+      api
+        .post('/api/2/calls/1234/', {
+          meta: {
+            name: '=1+1',
+            description: null,
+            tags: [
+              'apimetrics:meta:domain:google.apimetrics.xyz',
+              'apimetrics:meta:http:google_lb',
+              'apimetrics:meta:ns_host:Google+LLC',
+              'apimetrics:meta:server:gunicorn',
+              'apimetrics:meta:host:Google+LLC',
+            ],
+          },
+          request: {
+            method: 'GET',
+            url: 'http://google.apimetrics.xyz/get',
+            headers: [{key: 'Content-type', value: 'text/plain'}],
+            body: 'abc123',
+          },
+        })
+        .reply(200, callsResponse);
+    })
+    .command(['calls:edit', '--json', '--call-id', '1234', '--body=abc123'])
+    .it('Add body with existing content-type flag');
+
+  auth
+    .stdout()
+    .nock('https://client.apimetrics.io', (api) => {
+      api.get('/api/2/calls/1234/').reply(200, {
+        meta: {
+          domain: 'google.apimetrics.xyz',
+          description: null,
+          tags: [
+            'apimetrics:meta:domain:google.apimetrics.xyz',
+            'apimetrics:meta:http:google_lb',
+            'apimetrics:meta:ns_host:Google+LLC',
+            'apimetrics:meta:server:gunicorn',
+            'apimetrics:meta:host:Google+LLC',
+          ],
+          accept: null,
+          content_type: null,
+          owner: 'ag9zfmFwaW1ldHJpY3MtcWNyEQsSBFVzZXIYgIDA1PLekQoM',
+          name: '=1+1',
+          created: '2021-01-28T01:19:19.594763Z',
+          last_update: '2022-07-19T22:38:53.838839Z',
+          workspace: 'global',
+          project_id: 'ag9zfmFwaW1ldHJpY3MtcWNyEQsSBFVzZXIYgIDA1PLekQoM',
+        },
+        request: {
+          body: null,
+          parameters: [],
+          url: 'http://google.apimetrics.xyz/get',
+          auth_id: null,
+          headers: [],
+          token_id: null,
+          method: 'GET',
+        },
+        id: 'ag9zfmFwaW1ldHJpY3MtcWNyFwsSClRlc3RTZXR1cDIYgIDA05v5mwoM',
+      });
+      api
+        .post('/api/2/calls/1234/', {
+          meta: {
+            name: '=1+1',
+            description: null,
+            tags: [
+              'apimetrics:meta:domain:google.apimetrics.xyz',
+              'apimetrics:meta:http:google_lb',
+              'apimetrics:meta:ns_host:Google+LLC',
+              'apimetrics:meta:server:gunicorn',
+              'apimetrics:meta:host:Google+LLC',
+            ],
+          },
+          request: {
+            method: 'GET',
+            url: 'http://google.apimetrics.xyz/get',
+            headers: [{key: 'Content-Type', value: 'application/json'}],
+            body: 'abc123',
+          },
+        })
+        .reply(200, callsResponse);
+    })
+    .command(['calls:edit', '--json', '--call-id', '1234', '--body=abc123'])
+    .it('Add body with no content-type flag');
+
   noProject
     .stdout()
     .nock(


### PR DESCRIPTION
<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
When specifying the request body of a call, if the Content-Type header not set, it will default to application/json. This mimics the behavior of the web interface and prevents issues when the web interface tries to display the body.

Closes #105 

### Type

- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change

# Technical Description
<!-- 
How does this change work? Why was this approach chosen? Were any 
alternative approaches considered?
-->
When creating a call, if the user has not specified the content type header, the default is added to the list of headers. When editing, if the user passes the `--body` option and after all header editing has taken place, there is no content type header, the default will be added.

# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
