### PR TITLE
Implemented #113

### DIFF
--- a/src/commands/info/whoami.ts
+++ b/src/commands/info/whoami.ts
@@ -27,7 +27,8 @@ Name:                 Bob
 Email:                bob@example.com
 MFA enabled:          false
 Current Organization: companya
-Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
+Current Project Name: My Project
+Current Project ID:   ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
   ];
 
   public async run(): Promise<WhoamiResponse> {

--- a/src/commands/info/whoami.ts
+++ b/src/commands/info/whoami.ts
@@ -1,4 +1,4 @@
-import {Command} from '../../base-command';
+import {Command, T} from '../../base-command';
 
 export type WhoamiResponse = {
   success: boolean;
@@ -10,7 +10,10 @@ export type WhoamiResponse = {
     // eslint-disable-next-line camelcase
     current_org: string;
     // eslint-disable-next-line camelcase
-    current_project: string;
+    current_project: {
+      name: string;
+      id: string;
+    };
   };
 };
 
@@ -29,6 +32,12 @@ Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
 
   public async run(): Promise<WhoamiResponse> {
     const userinfo = await this.api.userinfo();
+    let projectName: string | undefined;
+
+    if (this.userConfig.project.current !== '') {
+      projectName = (await this.api.get<T.Project>(`projects/${this.api.project}`)).name;
+    }
+
     const data: Record<string, {title: string; value: any}> = {
       id: {
         title: 'ID',
@@ -50,8 +59,12 @@ Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
         title: 'Current Organization',
         value: this.userConfig.organization.current || '',
       },
-      currentProject: {
-        title: 'Current Project',
+      currentProjectName: {
+        title: 'Current Project Name',
+        value: projectName || '',
+      },
+      currentProjectID: {
+        title: 'Current Project ID',
         value: this.userConfig.project.current || '',
       },
     };
@@ -73,7 +86,10 @@ Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
         // eslint-disable-next-line camelcase
         current_org: data.currentOrg.value,
         // eslint-disable-next-line camelcase
-        current_project: data.currentProject.value,
+        current_project: {
+          name: data.currentProjectName.value,
+          id: data.currentProjectID.value,
+        },
       },
     };
   }

--- a/src/commands/info/whoami.ts
+++ b/src/commands/info/whoami.ts
@@ -35,7 +35,7 @@ Current Project ID:   ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM`,
     const userinfo = await this.api.userinfo();
     let projectName: string | undefined;
 
-    if (this.userConfig.project.current !== '') {
+    if (this.userConfig.project.current) {
       projectName = (await this.api.get<T.Project>(`projects/${this.api.project}`)).name;
     }
 

--- a/test/commands/info/whoami.test.ts
+++ b/test/commands/info/whoami.test.ts
@@ -20,6 +20,10 @@ const userinfo = {
   'https://client.apimetrics.io/fav_projects': [],
 };
 
+const project = {
+  name: 'A Project',
+};
+
 describe('info whoami', () => {
   const bearerAuth = test
     .do(() => {
@@ -33,10 +37,31 @@ describe('info whoami', () => {
       });
     })
     .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'})
+    .env({APIMETRICS_USERINFO_URL: 'https://auth.apimetrics.io/userinfo'});
+
+  const noProject = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'companya'},
+        project: {current: ''},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'bearer',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'})
     .env({APIMETRICS_USERINFO_URL: 'https://auth.apimetrics.io/userinfo'});
 
   bearerAuth
     .nock('https://auth.apimetrics.io', (api) => api.get('/userinfo').reply(200, userinfo))
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .get('/api/2/projects/ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM')
+        .reply(200, project)
+    )
     .stdout()
     .command(['info:whoami'])
     .it('Show current user information', (ctx) => {
@@ -45,7 +70,21 @@ Name:                 Bob
 Email:                bob@example.com
 MFA enabled:          false
 Current Organization: companya
-Current Project:      ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM
+Current Project Name: A Project
+Current Project ID:   ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM
 `);
+    });
+  noProject
+    .nock('https://auth.apimetrics.io', (api) => api.get('/userinfo').reply(200, userinfo))
+
+    .stdout()
+    .command(['info:whoami'])
+    .it('Show current user information', (ctx) => {
+      expect(ctx.stdout).to.equal(`ID:                   auth0|109e70845ef23eb4099c209p
+Name:                 Bob
+Email:                bob@example.com
+MFA enabled:          false
+Current Organization: companya
+Current Project Name: \nCurrent Project ID:   \n`); // Whitespace important here
     });
 });


### PR DESCRIPTION
<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
<!-- A brief, mostly non technical summary of what this change does -->

If the current project is set, we get it's details from the API to present it's name to the user.
Note: this is technically a breaking change as we change the schema for the --json output, as well as alter the name of the Current Project ID row, but we are still in 0.x.x so it is to be expected.

Closes #113 

### Type

- [x] Feature
- [ ] Bug Fix
- [x] Breaking Change

# Technical Description
If the current project ID is set, we fetch it's name from the API to present to the user.

## Usage
No change to command usage however output has been modified to:

```
EXAMPLES
  $ apimetrics info whoami
  ID:                   auth0|109e70845ef23eb4099c209p
  Name:                 Bob
  Email:                bob@example.com
  MFA enabled:          false
  Current Organization: companya
  Current Project Name: My Project
  Current Project ID:   ag9zfmFwaWasfHJpY3MtclpsEQsSBFVzZyu;gIDgpdG73QoM

```

## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/9adaef0c-7332-4e08-9e4b-f5fe99966f28)

# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
