### PR TITLE
Check for falsy refresh token values

### DIFF
--- a/src/base-command/auth.ts
+++ b/src/base-command/auth.ts
@@ -94,13 +94,17 @@ export class Auth {
    */
   public async logout(): Promise<void> {
     if (this.token.mode === Auth.AuthType.Device) {
-      try {
-        await HTTP.post(this.revokeUrl, {
-          // eslint-disable-next-line camelcase
-          body: {client_id: this.clientId, token: this.token.refresh},
-        });
-      } catch (error) {
-        ux.warn(`Failed to revoke refresh token. ${error}`);
+      if (this.token.refresh) {
+        try {
+          await HTTP.post(this.revokeUrl, {
+            // eslint-disable-next-line camelcase
+            body: {client_id: this.clientId, token: this.token.refresh},
+          });
+        } catch (error) {
+          ux.warn(`Failed to revoke refresh token. ${error}`);
+        }
+      } else {
+        ux.warn('Did not attempt to revoke refresh token as token was undefined.');
       }
     }
 

--- a/test/commands/auth/logout.test.ts
+++ b/test/commands/auth/logout.test.ts
@@ -1,8 +1,41 @@
 import {expect, test} from '@oclif/test';
-import * as fs from 'node:fs';
+import * as fs from 'fs-extra';
 import * as path from 'node:path';
 
 describe('auth logout', () => {
+  const withRefreshToken = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'abc123'},
+        project: {current: 'abc123'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        refresh: 'abc123',
+        mode: 'device',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'})
+    .env({APIMETRICS_CLIENT_ID: '123'})
+    .env({APIMETRICS_REVOKE_URL: 'https://auth.apimetrics.io/oauth/revoke'});
+
+  const noRefreshToken = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'abc123'},
+        project: {current: 'abc123'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        refresh: '',
+        mode: 'device',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'})
+    .env({APIMETRICS_REVOKE_URL: 'https://auth.apimetrics.io/oauth/revoke'});
+
   const auth = test
     .do(() => {
       fs.readdir('./.test', (err, files) => {
@@ -16,10 +49,33 @@ describe('auth logout', () => {
       });
     })
     .env({APIMETRICS_CONFIG_DIR: './.test'});
+
   auth
     .stdout()
     .command(['auth:logout'])
     .it('Log out', (ctx) => {
       expect(ctx.stdout).to.contain('Logged out');
+    });
+
+  withRefreshToken
+    .nock('https://auth.apimetrics.io', (api) =>
+      // eslint-disable-next-line camelcase
+      api.post('/oauth/revoke', {client_id: '123', token: 'abc123'}).reply(200, {})
+    )
+    .stdout()
+    .command(['auth:logout'])
+    .it('Log out and revoke refresh token', (ctx) => {
+      expect(ctx.stdout).to.contain('Logged out');
+    });
+
+  noRefreshToken
+    .stderr()
+    .stdout()
+    .command(['auth:logout'])
+    .it('Log out with falsy refresh token', (ctx) => {
+      expect(ctx.stdout).to.contain('Logged out');
+      expect(ctx.stderr).to.contain(
+        'Did not attempt to revoke refresh token as token was undefined.'
+      );
     });
 });


### PR DESCRIPTION


<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
Fix #117. Now if the refresh token is falsy, we don't call the API, just inform the user it was falsy instead.

### Type

- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change


## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/0fea9265-641d-4e56-8905-9a5d3376c236)

# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
