### PR TITLE
Added delete project

### DIFF
--- a/src/commands/projects/delete.ts
+++ b/src/commands/projects/delete.ts
@@ -1,0 +1,77 @@
+import {Flags} from '@oclif/core';
+import {Command, T} from '../../base-command';
+
+export default class Delete extends Command<{success: boolean}> {
+  static description = 'Delete the currently selected project or specify another to delete.';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --project-id ag9zfmFwaW1ldHlpPbCtcWNyMwsSDUFjY29lpo95kAab4GUiIHpYSTQxY2JEajkzcWRFbE5GTEVajkuY85RT7jdteFdmDA',
+  ];
+
+  static flags = {
+    'project-id': Flags.string({
+      description: 'ID of project to delete. Overrides apimetrics config project set.',
+      char: 'p',
+    }),
+    'org-id': Flags.string({
+      description: 'ID of organization to modify. Overrides apimetrics config org set.',
+      char: 'o',
+    }),
+  };
+
+  public async run(): Promise<{success: boolean}> {
+    const {flags} = await this.parse(Delete);
+
+    const orgId = flags['org-id'] ? flags['org-id'] : this.userConfig.organization.current;
+    if (orgId === undefined) {
+      throw new Error('Current organization not set. Run `apimetrics config org set` first.');
+    } else if (orgId === '') {
+      throw new Error('Personal projects not currently supported.');
+    }
+
+    const currentProject = this.api.project;
+
+    if (flags['project-id']) {
+      this.api.project = flags['project-id'];
+    }
+
+    if (!this.api.project) {
+      throw new Error(
+        'Current working project not set. Run `apimetrics config project set` first.'
+      );
+    }
+
+    const roles = await this.api.list<T.Access>(`projects/${this.api.project}/roles/`);
+    if (roles.length > 0) {
+      throw new Error(
+        `There ${roles.length === 1 ? 'is' : 'are'} ${roles.length} role${
+          roles.length === 1 ? '' : 's'
+        } currently with access to this project. Please remove all roles before deleting the project.`
+      );
+    }
+
+    const accounts = await this.api.list<T.Access>(`projects/${this.api.project}/access/`);
+    if (accounts.length > 0) {
+      throw new Error(
+        `There ${accounts.length === 1 ? 'is' : 'are'} ${accounts.length} account${
+          accounts.length === 1 ? '' : 's'
+        } currently with access to this project. Please remove all accounts before deleting the project.`
+      );
+    }
+
+    await this.api.delete(`organizations/${orgId}/projects/${this.api.project}/`);
+
+    if (this.api.project === currentProject) {
+      // If the user has deleted their current working project, clear
+      // their current working project.
+      this.userConfig.project.current = undefined;
+      await this.userConfig.save();
+      this.log(
+        'Deleted current working project. You will need to run `apimetrics config project set`.'
+      );
+    }
+
+    return {success: true};
+  }
+}

--- a/test/commands/projects/delete.test.ts
+++ b/test/commands/projects/delete.test.ts
@@ -1,0 +1,194 @@
+import {expect, test} from '@oclif/test';
+import * as fs from 'fs-extra';
+
+describe('projects delete', () => {
+  const auth = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'abc123'},
+        project: {current: 'abc123'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'device',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'});
+
+  const noProject = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: 'abc123'},
+        project: {},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'device',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'});
+
+  const noOrg = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {},
+        project: {},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'device',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'});
+
+  const personalProject = test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: ''},
+        project: {},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'device',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'});
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .get('/api/2/projects/abc123/roles/')
+        .reply(200, {meta: {}, results: []})
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, {meta: {}, results: []})
+        .delete('/api/2/organizations/abc123/projects/abc123/')
+        .reply(200, {})
+    )
+    .stdout()
+    .command(['projects:delete'])
+    .it('Delete current working project', (ctx) => {
+      expect(ctx.stdout).to.contain(
+        'Deleted current working project. You will need to run `apimetrics config project set`.'
+      );
+    });
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .get('/api/2/projects/abc456/roles/')
+        .reply(200, {meta: {}, results: []})
+        .get('/api/2/projects/abc456/access/')
+        .reply(200, {meta: {}, results: []})
+        .delete('/api/2/organizations/abc123/projects/abc456/')
+        .reply(200, {})
+    )
+    .stdout()
+    .command(['projects:delete', '-p=abc456'])
+    .it('Delete project');
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .get('/api/2/projects/abc456/roles/')
+        .reply(200, {meta: {}, results: []})
+        .get('/api/2/projects/abc456/access/')
+        .reply(200, {meta: {}, results: []})
+        .delete('/api/2/organizations/def/projects/abc456/')
+        .reply(200, {})
+    )
+    .stdout()
+    .command(['projects:delete', '-p=abc456', '-o=def'])
+    .it('Delete project passing org ID');
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api.get('/api/2/projects/abc123/roles/').reply(200, {meta: {}, results: ['']})
+    )
+    .stdout()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'There is 1 role currently with access to this project. Please remove all roles before deleting the project.'
+      );
+    })
+    .it('Delete project with role');
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api.get('/api/2/projects/abc123/roles/').reply(200, {meta: {}, results: ['', '', '']})
+    )
+    .stdout()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'There are 3 roles currently with access to this project. Please remove all roles before deleting the project.'
+      );
+    })
+    .it('Delete project with multiple roles');
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .get('/api/2/projects/abc123/roles/')
+        .reply(200, {meta: {}, results: []})
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, {meta: {}, results: ['']})
+    )
+    .stdout()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'There is 1 account currently with access to this project. Please remove all accounts before deleting the project.'
+      );
+    })
+    .it('Delete project with account');
+
+  auth
+    .nock('https://client.apimetrics.io', (api) =>
+      api
+        .get('/api/2/projects/abc123/roles/')
+        .reply(200, {meta: {}, results: []})
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, {meta: {}, results: ['', '', '']})
+    )
+    .stdout()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'There are 3 accounts currently with access to this project. Please remove all accounts before deleting the project.'
+      );
+    })
+    .it('Delete project with multiple accounts');
+
+  noProject
+    .stderr()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'Current working project not set. Run `apimetrics config project set` first.'
+      );
+    })
+    .it('No project set');
+
+  noOrg
+    .stderr()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'Current organization not set. Run `apimetrics config org set` first.'
+      );
+    })
+    .it('No org set');
+
+  personalProject
+    .stderr()
+    .command(['projects:delete'])
+    .catch((error) => {
+      expect(error.message).to.contain('Personal projects not currently supported.');
+    })
+    .it('Personal projects');
+});


### PR DESCRIPTION


<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
The delete project command has been implemented to allow users to delete a project from an organisation. 

Closes #93 

### Type

- [x] Feature
- [ ] Bug Fix
- [ ] Breaking Change

# Technical Description
If there are any roles or accounts with access to the project, the user will receive an error stating  that these must be removed first.

If the user does not specify the '-p' flag, then the current working project will be deleted and set to undefined. The user will be informed of the need for them to set a new current working project.

## Usage
```
Delete the currently selected project or specify another to delete.

USAGE
  $ apimetrics projects delete [--json] [-p <value>] [-o <value>]

FLAGS
  -o, --org-id=<value>      ID of organization to modify. Overrides apimetrics config org set.
  -p, --project-id=<value>  ID of project to delete. Overrides apimetrics config project set.

GLOBAL FLAGS
  --json  Format output as json.

DESCRIPTION
  Delete the currently selected project or specify another to delete.

EXAMPLES
  $ apimetrics projects delete

  $ apimetrics projects delete --project-id ag9zfmFwaW1ldHlpPbCtcWNyMwsSDUFjY29lpo95kAab4GUiIHpYSTQxY2JEajkzcWRFbE5GTEVajkuY85RT7jdteFdmDA
```

## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/12553214-1f62-4248-9bbb-1a77d8e1a8b2)
The user deletes their current working project.

![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/4af68c34-7444-4945-8d76-b0f0ea0949e1)
The user tries to delete a project that currently has an account with access.

# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
