### PR TITLE
Allow user to specify user using email

### DIFF
--- a/src/base-command/util.ts
+++ b/src/base-command/util.ts
@@ -88,3 +88,24 @@ export function addRemoveStrings(current: string[], add: string[], remove: strin
 
   return current;
 }
+
+/**
+ * Fetch the ID of a user within this organisation by their email address.
+ * @param org List of organisation accounts
+ * @param email Email to fetch ID for
+ * @returns User ID
+ * @throws There are multiple users with this email
+ * @throws No user with this email exists
+ */
+export function getUserIdFromOrg(org: T.OrgAccount[], email: string): string {
+  const accounts = org.filter((account) => account.email === email)
+  if (accounts.length > 1) {
+    throw new Error(`There are multiple users with the email ${email}. Please use their ID instead.`)
+  }
+
+  if (accounts.length === 0) {
+    throw new Error(`No users with the email ${email} exist. Please use their ID instead.`)
+  }
+
+  return accounts[0].id
+}

--- a/test/commands/org/accounts/edit.test.ts
+++ b/test/commands/org/accounts/edit.test.ts
@@ -65,6 +65,22 @@ const noRoles = {
   logins_count: 2,
 };
 
+const orgAccounts = {
+  meta: {},
+  results: [
+    {email: 'abc@example.com', id: 'auth0|abc123'},
+    {email: 'def@example.com', id: 'auth0|def123'},
+    {email: 'ghi@example.com', id: 'auth0|ghi123'},
+    {email: 'jkl@example.com', id: 'auth0|jkl123'},
+    {email: 'mno@example.com', id: 'auth0|mno123'},
+    {email: 'pqr@example.com', id: 'auth0|pqr123'},
+    {email: 'stu@example.com', id: 'auth0|stu123'},
+    {email: 'vwx@example.com', id: 'auth0|vwx123'},
+    {email: 'yza@example.com', id: 'auth0|yza123'},
+    {email: 'yza@example.com', id: 'auth0|yza123'},
+  ],
+};
+
 describe('org accounts edit', () => {
   const bearerAuth = test
     .do(() => {
@@ -127,6 +143,35 @@ describe('org accounts edit', () => {
       '--json',
     ])
     .it('Add and remove roles from a user with role in app_metadata (--json)', (ctx) => {
+      const output = JSON.parse(ctx.stdout);
+      expect(output).to.deep.equal({success: true});
+    });
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api
+        .get('/api/2/organizations/abc123/roles/')
+        .reply(200, roles)
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/organizations/abc123/accounts/auth0%7Cabc123')
+        .reply(200, appMetadata);
+
+      // These calls are async
+      api.post('/api/2/organizations/abc123/accounts/auth0%7Cabc123/role/A_ROLE/').reply(200, {});
+      api
+        .delete('/api/2/organizations/abc123/accounts/auth0%7Cabc123/role/ANOTHER_ROLE/')
+        .reply(200, {});
+    })
+    .stdout()
+    .command([
+      'org:accounts:edit',
+      '--add-role=A_ROLE',
+      '--remove-role=ANOTHER_ROLE',
+      '--user-id=abc@example.com',
+      '--json',
+    ])
+    .it('Add and remove roles from a user using email', (ctx) => {
       const output = JSON.parse(ctx.stdout);
       expect(output).to.deep.equal({success: true});
     });

--- a/test/commands/org/accounts/remove.test.ts
+++ b/test/commands/org/accounts/remove.test.ts
@@ -1,6 +1,22 @@
 import {expect, test} from '@oclif/test';
 import * as fs from 'fs-extra';
 
+const orgAccounts = {
+  meta: {},
+  results: [
+    {email: 'abc@example.com', id: 'auth0|abc123'},
+    {email: 'def@example.com', id: 'auth0|def123'},
+    {email: 'ghi@example.com', id: 'auth0|ghi123'},
+    {email: 'jkl@example.com', id: 'auth0|jkl123'},
+    {email: 'mno@example.com', id: 'auth0|mno123'},
+    {email: 'pqr@example.com', id: 'auth0|pqr123'},
+    {email: 'stu@example.com', id: 'auth0|stu123'},
+    {email: 'vwx@example.com', id: 'auth0|vwx123'},
+    {email: 'yza@example.com', id: 'auth0|yza123'},
+    {email: 'yza@example.com', id: 'auth0|yza123'},
+  ],
+};
+
 describe('org accounts remove', () => {
   const bearerAuth = test
     .do(() => {
@@ -49,6 +65,21 @@ describe('org accounts remove', () => {
     .stdout()
     .command(['org:accounts:remove', '--user-id=qwerty', '--json'])
     .it('Remove user (--json)', (ctx) => {
+      const output = JSON.parse(ctx.stdout);
+      expect(output).to.deep.equal({success: true});
+    });
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .delete('/api/2/organizations/abc123/accounts/auth0%7Cabc123/')
+        .reply(200, {});
+    })
+    .stdout()
+    .command(['org:accounts:remove', '--user-id=abc@example.com', '--json'])
+    .it('Remove user using email (--json)', (ctx) => {
       const output = JSON.parse(ctx.stdout);
       expect(output).to.deep.equal({success: true});
     });

--- a/test/commands/projects/accounts/edit.test.ts
+++ b/test/commands/projects/accounts/edit.test.ts
@@ -141,40 +141,6 @@ describe('project accounts edit', () => {
       expect(output).to.deep.equal({success: true, warnings: []});
     });
 
-  bearerAuth
-    .nock('https://client.apimetrics.io', (api) => {
-      api
-        .get('/api/2/organizations/def/accounts/')
-        .reply(200, orgAccounts)
-        .get('/api/2/projects/abc123/access/')
-        .reply(200, projectAccess);
-      api
-        .post('/api/2/projects/abc123/access/', {access_level: 'OWNER', account_id: 'abc123'})
-        .reply(200, {});
-      api
-        .post('/api/2/projects/abc123/access/', {access_level: 'EDITOR', account_id: 'abc123'})
-        .reply(200, {});
-      api
-        .post('/api/2/projects/abc123/access/', {access_level: 'ANALYST', account_id: 'abc123'})
-        .reply(200, {});
-      api
-        .post('/api/2/projects/abc123/access/', {access_level: 'VIEWER', account_id: 'abc123'})
-        .reply(200, {});
-    })
-    .stdout()
-    .command([
-      'projects:accounts:edit',
-      '--add-owner=abc123',
-      '--add-editor=abc123',
-      '--add-analyst=abc123',
-      '--add-viewer=abc123',
-      '-o=def',
-      '--json',
-    ])
-    .it('Specify organisation ID', (ctx) => {
-      const output = JSON.parse(ctx.stdout);
-      expect(output).to.deep.equal({success: true, warnings: []});
-    });
 
   bearerAuth
     .nock('https://client.apimetrics.io', (api) => {
@@ -319,7 +285,9 @@ describe('project accounts edit', () => {
   bearerAuth
     .nock('https://client.apimetrics.io', (api) => {
       api
-        .get('/api/2/organizations/abc123/accounts/')
+        .get('/api/2/project/')
+        .reply(200, {org_id: 'def'})
+        .get('/api/2/organizations/def/accounts/')
         .reply(200, orgAccounts)
         .get('/api/2/projects/qwerty/access/')
         .reply(200, projectAccess);
@@ -427,5 +395,5 @@ describe('project accounts edit', () => {
         'No users with the email qwerty@example.com exist. Please use their ID instead.'
       );
     })
-    .it('Multiple users with the same email');
+    .it('No user with email');
 });

--- a/test/commands/projects/accounts/edit.test.ts
+++ b/test/commands/projects/accounts/edit.test.ts
@@ -76,6 +76,22 @@ const projectAccess = {
   ],
 };
 
+const orgAccounts = {
+  meta: {},
+  results: [
+    {email: 'abc@example.com', id: 'auth0|abc123'},
+    {email: 'def@example.com', id: 'auth0|def123'},
+    {email: 'ghi@example.com', id: 'auth0|ghi123'},
+    {email: 'jkl@example.com', id: 'auth0|jkl123'},
+    {email: 'mno@example.com', id: 'auth0|mno123'},
+    {email: 'pqr@example.com', id: 'auth0|pqr123'},
+    {email: 'stu@example.com', id: 'auth0|stu123'},
+    {email: 'vwx@example.com', id: 'auth0|vwx123'},
+    {email: 'yza@example.com', id: 'auth0|yza123'},
+    {email: 'yza@example.com', id: 'auth0|yza123'},
+  ],
+};
+
 describe('project accounts edit', () => {
   const bearerAuth = test
     .do(() => {
@@ -93,7 +109,11 @@ describe('project accounts edit', () => {
 
   bearerAuth
     .nock('https://client.apimetrics.io', (api) => {
-      api.get('/api/2/projects/abc123/access/').reply(200, projectAccess);
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, projectAccess);
       api
         .post('/api/2/projects/abc123/access/', {access_level: 'OWNER', account_id: 'abc123'})
         .reply(200, {});
@@ -120,9 +140,86 @@ describe('project accounts edit', () => {
       const output = JSON.parse(ctx.stdout);
       expect(output).to.deep.equal({success: true, warnings: []});
     });
+
   bearerAuth
     .nock('https://client.apimetrics.io', (api) => {
-      api.get('/api/2/projects/abc123/access/').reply(200, projectAccess);
+      api
+        .get('/api/2/organizations/def/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, projectAccess);
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'OWNER', account_id: 'abc123'})
+        .reply(200, {});
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'EDITOR', account_id: 'abc123'})
+        .reply(200, {});
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'ANALYST', account_id: 'abc123'})
+        .reply(200, {});
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'VIEWER', account_id: 'abc123'})
+        .reply(200, {});
+    })
+    .stdout()
+    .command([
+      'projects:accounts:edit',
+      '--add-owner=abc123',
+      '--add-editor=abc123',
+      '--add-analyst=abc123',
+      '--add-viewer=abc123',
+      '-o=def',
+      '--json',
+    ])
+    .it('Specify organisation ID', (ctx) => {
+      const output = JSON.parse(ctx.stdout);
+      expect(output).to.deep.equal({success: true, warnings: []});
+    });
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, projectAccess);
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'OWNER', account_id: 'auth0|def123'})
+        .reply(200, {});
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'EDITOR', account_id: 'abc123'})
+        .reply(200, {});
+      api
+        .post('/api/2/projects/abc123/access/', {access_level: 'ANALYST', account_id: 'abc123'})
+        .reply(200, {});
+      api
+        .post('/api/2/projects/abc123/access/', {
+          access_level: 'VIEWER',
+          account_id: 'auth0|abc123',
+        })
+        .reply(200, {});
+    })
+    .stdout()
+    .command([
+      'projects:accounts:edit',
+      '--add-owner=def@example.com',
+      '--add-editor=abc123',
+      '--add-analyst=abc123',
+      '--add-viewer=abc@example.com',
+      '--json',
+    ])
+    .it('Add user roles specifying by email', (ctx) => {
+      const output = JSON.parse(ctx.stdout);
+      expect(output).to.deep.equal({success: true, warnings: []});
+    });
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, projectAccess);
       api
         .delete(
           '/api/2/projects/abc123/access/ag9zfmFwaW1ldHJpY3MtcWNyGwsSDkFjY291bnRQcm9qZWN0GICA4NXQ68MIDA/'
@@ -157,9 +254,56 @@ describe('project accounts edit', () => {
       const output = JSON.parse(ctx.stdout);
       expect(output).to.deep.equal({success: true, warnings: []});
     });
+
   bearerAuth
     .nock('https://client.apimetrics.io', (api) => {
-      api.get('/api/2/projects/abc123/access/').reply(200, projectAccess);
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, projectAccess);
+      api
+        .delete(
+          '/api/2/projects/abc123/access/ag9zfmFwaW1ldHJpY3MtcWNyGwsSDkFjY291bnRQcm9qZWN0GICA4NXQ68MIDA/'
+        )
+        .reply(200, {});
+      api
+        .delete(
+          '/api/2/projects/abc123/access/ag9zfmFwaW1ldHJpY3MtcWNyGwsSDkFjY291bnRQcm9qZWN0GICA4NWnwe4JDA/'
+        )
+        .reply(200, {});
+      api
+        .delete(
+          '/api/2/projects/abc123/access/ag9zfmFwaW1ldHJpY3MtcWNyGwsSDkFjY291bnRQcm9qZWN0GICA4LX4hb4KDA/'
+        )
+        .reply(200, {});
+      api
+        .delete(
+          '/api/2/projects/abc123/access/ag9zfmFwaW1ldHJpY3MtcWNyGwsSDkFjY291bnRQcm9qZWN0GICA4KX0xcgKDA/'
+        )
+        .reply(200, {});
+    })
+    .stdout()
+    .command([
+      'projects:accounts:edit',
+      '--remove-owner=abc@example.com',
+      '--remove-editor=auth0|647ljfdgdnhnfjsgzbfdjgjbsnvknsh',
+      '--remove-analyst=auth0|647ljfdgdnhnfjsgzbfdjgjbsnvknsh',
+      '--remove-viewer=auth0|mynameisbob',
+      '--json',
+    ])
+    .it('Remove user roles by email', (ctx) => {
+      const output = JSON.parse(ctx.stdout);
+      expect(output).to.deep.equal({success: true, warnings: []});
+    });
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/abc123/access/')
+        .reply(200, projectAccess);
     })
     .stderr()
     .stdout()
@@ -171,9 +315,14 @@ describe('project accounts edit', () => {
         warnings: ['Could not find account with ID auth0|qwerty for access level OWNER. Skipping.'],
       });
     });
+
   bearerAuth
     .nock('https://client.apimetrics.io', (api) => {
-      api.get('/api/2/projects/qwerty/access/').reply(200, projectAccess);
+      api
+        .get('/api/2/organizations/abc123/accounts/')
+        .reply(200, orgAccounts)
+        .get('/api/2/projects/qwerty/access/')
+        .reply(200, projectAccess);
       api
         .delete(
           '/api/2/projects/qwerty/access/ag9zfmFwaW1ldHJpY3MtcWNyGwsSDkFjY291bnRQcm9qZWN0GICA4NXQ68MIDA/'
@@ -209,4 +358,74 @@ describe('project accounts edit', () => {
       const output = JSON.parse(ctx.stdout);
       expect(output).to.deep.equal({success: true, warnings: []});
     });
+
+  test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {},
+        project: {current: 'abc123'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'bearer',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'})
+    .stderr()
+    .command(['projects:accounts:edit', '--remove-owner=auth0|qwerty', '--json'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'Current organization not set. Run `apimetrics config org set` first.'
+      );
+    })
+    .it('No organisation set');
+
+  test
+    .do(() => {
+      fs.writeJsonSync('./.test/config.json', {
+        organization: {current: ''},
+        project: {current: 'abc123'},
+      });
+      fs.writeJsonSync('./.test/auth.json', {
+        token: 'abc123',
+        mode: 'bearer',
+      });
+    })
+    .env({APIMETRICS_CONFIG_DIR: './.test'})
+    .env({APIMETRICS_API_URL: 'https://client.apimetrics.io/api/2/'})
+    .stderr()
+    .command(['projects:accounts:edit', '--remove-owner=auth0|qwerty', '--json'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'Personal projects not currently supported. Please use web interface instead.'
+      );
+    })
+    .it('Personal projects');
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api.get('/api/2/organizations/abc123/accounts/').reply(200, orgAccounts);
+    })
+    .stderr()
+    .command(['projects:accounts:edit', '--add-owner=yza@example.com', '--json'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'There are multiple users with the email yza@example.com. Please use their ID instead.'
+      );
+    })
+    .it('Multiple users with the same email');
+
+  bearerAuth
+    .nock('https://client.apimetrics.io', (api) => {
+      api.get('/api/2/organizations/abc123/accounts/').reply(200, orgAccounts);
+    })
+    .stderr()
+    .command(['projects:accounts:edit', '--add-owner=qwerty@example.com', '--json'])
+    .catch((error) => {
+      expect(error.message).to.contain(
+        'No users with the email qwerty@example.com exist. Please use their ID instead.'
+      );
+    })
+    .it('Multiple users with the same email');
 });


### PR DESCRIPTION
<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
Now for the commands where the user input an ID for operations, an email is also supported. Emails can only be used if the user who's email it is is a member of the organisation. If the user is not a member of the organisation, this will not work and an error will be returned.

Closes #94

### Type

- [x] Feature
- [ ] Bug Fix
- [ ] Breaking Change

# Technical Description
It is possible for multiple users to share the same email (e.g. social login). In this case, if there are two accounts with the same email on an org, the operation will also fail. When the user specifies a project using the -p flag, and this project does not match the current one, details about the project will be fetched from the API and the organisation set to the org of the project.

## Usage
~~There has been a slight change to the flags of the `projects:accounts:edit` command as a result of this change. Now there is an optional organization-id flag that allows the user to set the current org inline. This is because this command now makes use of an organisation API.~~

No change to usage. Previous change to usage has been reverted in favor of fetching organisation ID from project.

# Self Review

- [x] I have commented my code where needed, including JSDoc / TSDoc
- [x] I have added / updated command tests
- [x] I have run `npm run test` and it generates no new errors or warnings
- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
