### PR TITLE
Add autocomplete for commands and flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^3.15.1",
+        "@oclif/plugin-autocomplete": "^3.0.4",
         "@oclif/plugin-help": "^6.0.9",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
@@ -1386,6 +1387,31 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/plugin-autocomplete": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.0.4.tgz",
+      "integrity": "sha512-GaksKwIM/dop8ax/A5/HDL7/WVWLhxrK/exIayG2d3B9I5IdXqHKNBWcO3jlucKsaZ8UjxQODqBVq7t+wcvU6w==",
+      "dependencies": {
+        "@oclif/core": "^3.15.1",
+        "chalk": "^5.3.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.9"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/plugin-autocomplete/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@oclif/plugin-help": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@oclif/core": "^3.15.1",
+    "@oclif/plugin-autocomplete": "^3.0.4",
     "@oclif/plugin-help": "^6.0.9",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
@@ -57,7 +58,8 @@
     "dirname": "apimetrics",
     "commands": "./dist/commands",
     "plugins": [
-      "@oclif/plugin-help"
+      "@oclif/plugin-help",
+      "@oclif/plugin-autocomplete"
     ],
     "topicSeparator": " ",
     "topics": {


### PR DESCRIPTION


<!-- 
This PR template is designed to help you write PRs that are easy for us 
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
Support for autocompletion of commands has been added through the use of the `@oclif/plugin-autocomplete` package. This supports generating auto completion scripts for zsh, bash and powershell by using the command `apimetrics autocomplete`.

### Type

- [x] Feature
- [ ] Bug Fix
- [ ] Breaking Change

## Usage
```
Display autocomplete installation instructions.

USAGE
  $ apimetrics autocomplete [SHELL] [-r]

ARGUMENTS
  SHELL  (zsh|bash|powershell) Shell type

FLAGS
  -r, --refresh-cache  Refresh cache (ignores displaying instructions)

DESCRIPTION
  Display autocomplete installation instructions.

EXAMPLES
  $ apimetrics autocomplete

  $ apimetrics autocomplete bash

  $ apimetrics autocomplete zsh

  $ apimetrics autocomplete powershell

  $ apimetrics autocomplete --refresh-cache

```

## Screenshots
![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/50fab6a2-c1b0-48c0-8ed2-3fb7f67cca38)
Generating the autocomplete script for the users shell

![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/36c1b01d-8fa8-4948-b147-887e0d0eb8aa)
Using `<tab> <tab>` to generate autocomplete options for commands

![image](https://github.com/APImetrics/APIm-CLI/assets/67638596/b186f5e9-2bc3-45dc-8441-b05d26387ec2)
Using `<tab> <tab>` to generate autocomplete options for flags

# Self Review

- [x] I have reviewed my code to ensure there are no artifacts left over from development
- [x] I have tested my code to ensure it functions as intended
