### PR TITLE
Fix dynamic import of open

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "importHelpers": true,
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION



# Summary
This should fix an issue with dynamic import of `open` in `src/base-command/auth.ts`. This fixes the regression in 0e5d72f9d9edceb5fbfed151cd54c4edfd0f34df


### Type

- [ ] Feature
- [x] Bug Fix
- [ ] Breaking Change

# Technical Description
Fix this error
```
Error: require() of ES Module /home/mnickson/source/APImetrics/cli/node_modules/open/index.js from /home/mnickson/source/APImetrics/cli/src/base-command/auth.ts not supported.
Instead change the require of index.js in /home/mnickson/source/APImetrics/cli/src/base-command/auth.ts to a dynamic import() which is available in all CommonJS modules.
    at Object.error (/home/mnickson/source/APImetrics/cli/node_modules/@oclif/core/lib/errors/index.js:52:15)
    at Login.error (/home/mnickson/source/APImetrics/cli/node_modules/@oclif/core/lib/command.js:177:23)
    at Login.catch (/home/mnickson/source/APImetrics/cli/src/base-command/command.ts:30:18)
    at Login._run (/home/mnickson/source/APImetrics/cli/node_modules/@oclif/core/lib/command.js:308:29)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Config.runCommand (/home/mnickson/source/APImetrics/cli/node_modules/@oclif/core/lib/config/config.js:417:25)
    at async run (/home/mnickson/source/APImetrics/cli/node_modules/@oclif/core/lib/main.js:85:16)
    at async /home/mnickson/source/APImetrics/cli/bin/dev.js:5:3

```
Typescript was transforming the `await import(...)` into a `require(...)` and thus causing this error. Switching to `NodeNext` fixes this issue.

# Self Review

- [x] I have run `npm run test` and it generates no new errors or warnings
